### PR TITLE
Pr 01 initial cut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.idea/

--- a/pico-statsd/src/main/scala/org/pico/statsd/CounterMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/CounterMetric.scala
@@ -1,14 +1,12 @@
 package org.pico.statsd
 
-import com.timgroup.statsd.StatsDClient
-
 /**
   * Classifies value as a counter metric.
   * The trait is sealed so only smart constructors can be used to create instances.
   */
 sealed trait CounterMetric[A] {
   def tags(value: A): List[String]
-  def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
+  def send(client: StatsdClient, aspect: String, value: A, extraTags: List[String]): Unit
 }
 
 object CounterMetric {
@@ -20,7 +18,7 @@ object CounterMetric {
     */
   def integral[A](toValue: A => Long, toTags: A => List[String]): CounterMetric[A] = new CounterMetric[A] {
     def tags(value: A) = toTags(value)
-    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+    def send(client: StatsdClient, aspect: String, v: A, t: List[String]): Unit =
       client.count(aspect, toValue(v), t ++ tags(v): _*)
   }
   

--- a/pico-statsd/src/main/scala/org/pico/statsd/CounterMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/CounterMetric.scala
@@ -2,12 +2,22 @@ package org.pico.statsd
 
 import com.timgroup.statsd.StatsDClient
 
+/**
+  * Classifies value as a counter metric.
+  * The trait is sealed so only smart constructors can be used to create instances.
+  */
 sealed trait CounterMetric[A] {
   def tags(value: A): List[String]
   def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
 }
 
 object CounterMetric {
+  /**
+    * Construct [[CounterMetric]] instance for a given type.
+    * Counters can only accept integral values
+    * @param toValue maps the value to counter value
+    * @param toTags maps the value to value specific tags
+    */
   def integral[A](toValue: A => Long, toTags: A => List[String]): CounterMetric[A] = new CounterMetric[A] {
     def tags(value: A) = toTags(value)
     def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =

--- a/pico-statsd/src/main/scala/org/pico/statsd/CounterMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/CounterMetric.scala
@@ -1,0 +1,20 @@
+package org.pico.statsd
+
+import com.timgroup.statsd.StatsDClient
+
+sealed trait CounterMetric[A] {
+  def tags(value: A): List[String]
+  def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
+}
+
+object CounterMetric {
+  def integral[A](toValue: A => Long, toTags: A => List[String]): CounterMetric[A] = new CounterMetric[A] {
+    def tags(value: A) = toTags(value)
+    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+      client.count(aspect, toValue(v), t ++ tags(v): _*)
+  }
+  
+  implicit val intIsCounterMetric  = integral[Int](_.toLong, _ => Nil)
+  implicit val longIsCounterMetric = integral[Long](identity, _ => Nil)
+  implicit val byteIsCounterMetric = integral[Byte](_.toLong, _ => Nil)
+}

--- a/pico-statsd/src/main/scala/org/pico/statsd/GaugeMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/GaugeMetric.scala
@@ -2,18 +2,33 @@ package org.pico.statsd
 
 import com.timgroup.statsd.StatsDClient
 
+/**
+  * Classifies value as a gauge metric.
+  * The trait is sealed so only smart constructors can be used to create instances.
+  */
 sealed trait GaugeMetric[A] {
   def tags(value: A): List[String]
+  
   def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
 }
 
 object GaugeMetric {
+  /**
+    * Construct a [[GaugeMetric]] instance that accepts integral values for a given type.
+    * @param toValue maps the value to an integral value
+    * @param toTags maps the value to value specific tags
+    */
   def integral[A](toValue: A => Long, toTags: A => List[String]): GaugeMetric[A] = new GaugeMetric[A] {
     def tags(value: A) = toTags(value)
     def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
       client.gauge(aspect, toValue(v), t ++ tags(v): _*)
   }
   
+  /**
+    * Construct a [[GaugeMetric]] instance that accepts fractional values for a given type.
+    * @param toValue maps the value to an fractional value
+    * @param toTags maps the value to value specific tags
+    */
   def fractional[A](toValue: A => Double, toTags: A => List[String]): GaugeMetric[A] = new GaugeMetric[A] {
     def tags(value: A) = toTags(value)
     def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =

--- a/pico-statsd/src/main/scala/org/pico/statsd/GaugeMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/GaugeMetric.scala
@@ -1,7 +1,5 @@
 package org.pico.statsd
 
-import com.timgroup.statsd.StatsDClient
-
 /**
   * Classifies value as a gauge metric.
   * The trait is sealed so only smart constructors can be used to create instances.
@@ -9,7 +7,7 @@ import com.timgroup.statsd.StatsDClient
 sealed trait GaugeMetric[A] {
   def tags(value: A): List[String]
   
-  def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
+  def send(client: StatsdClient, aspect: String, value: A, extraTags: List[String]): Unit
 }
 
 object GaugeMetric {
@@ -20,7 +18,7 @@ object GaugeMetric {
     */
   def integral[A](toValue: A => Long, toTags: A => List[String]): GaugeMetric[A] = new GaugeMetric[A] {
     def tags(value: A) = toTags(value)
-    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+    def send(client: StatsdClient, aspect: String, v: A, t: List[String]): Unit =
       client.gauge(aspect, toValue(v), t ++ tags(v): _*)
   }
   
@@ -31,7 +29,7 @@ object GaugeMetric {
     */
   def fractional[A](toValue: A => Double, toTags: A => List[String]): GaugeMetric[A] = new GaugeMetric[A] {
     def tags(value: A) = toTags(value)
-    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+    def send(client: StatsdClient, aspect: String, v: A, t: List[String]): Unit =
       client.gauge(aspect, toValue(v), t ++ tags(v): _*)
   }
   

--- a/pico-statsd/src/main/scala/org/pico/statsd/GaugeMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/GaugeMetric.scala
@@ -1,0 +1,28 @@
+package org.pico.statsd
+
+import com.timgroup.statsd.StatsDClient
+
+sealed trait GaugeMetric[A] {
+  def tags(value: A): List[String]
+  def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
+}
+
+object GaugeMetric {
+  def integral[A](toValue: A => Long, toTags: A => List[String]): GaugeMetric[A] = new GaugeMetric[A] {
+    def tags(value: A) = toTags(value)
+    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+      client.gauge(aspect, toValue(v), t ++ tags(v): _*)
+  }
+  
+  def fractional[A](toValue: A => Double, toTags: A => List[String]): GaugeMetric[A] = new GaugeMetric[A] {
+    def tags(value: A) = toTags(value)
+    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+      client.gauge(aspect, toValue(v), t ++ tags(v): _*)
+  }
+  
+  implicit val intIsGaugeMetric    = integral[Int](_.toLong, _ => Nil)
+  implicit val longIsGaugeMetric   = integral[Long](identity, _ => Nil)
+  implicit val byteIsGaugeMetric   = integral[Byte](_.toLong, _ => Nil)
+  implicit val floatIsGaugeMetric  = fractional[Float](_.toDouble, _ => Nil)
+  implicit val doubleIsGaugeMetric = fractional[Double](identity, _ => Nil)
+}

--- a/pico-statsd/src/main/scala/org/pico/statsd/HistogramMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/HistogramMetric.scala
@@ -1,14 +1,12 @@
 package org.pico.statsd
 
-import com.timgroup.statsd.StatsDClient
-
 /**
   * Classifies value as a histogram metric.
   * The trait is sealed so only smart constructors can be used to create instances.
   */
 sealed trait HistogramMetric[A] {
   def tags(value: A): List[String]
-  def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
+  def send(client: StatsdClient, aspect: String, value: A, extraTags: List[String]): Unit
 }
 
 object HistogramMetric {
@@ -19,7 +17,7 @@ object HistogramMetric {
     */
   def integral[A](toValue: A => Long, toTags: A => List[String]): HistogramMetric[A] = new HistogramMetric[A] {
     def tags(value: A) = toTags(value)
-    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+    def send(client: StatsdClient, aspect: String, v: A, t: List[String]): Unit =
       client.histogram(aspect, toValue(v), t ++ tags(v): _*)
   }
   
@@ -30,7 +28,7 @@ object HistogramMetric {
     */
   def fractional[A](toValue: A => Double, toTags: A => List[String]): HistogramMetric[A] = new HistogramMetric[A] {
     def tags(value: A) = toTags(value)
-    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+    def send(client: StatsdClient, aspect: String, v: A, t: List[String]): Unit =
       client.histogram(aspect, toValue(v), t ++ tags(v): _*)
   }
   

--- a/pico-statsd/src/main/scala/org/pico/statsd/HistogramMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/HistogramMetric.scala
@@ -1,0 +1,29 @@
+package org.pico.statsd
+
+import com.timgroup.statsd.StatsDClient
+
+sealed trait HistogramMetric[A] {
+  def tags(value: A): List[String]
+  def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
+}
+
+object HistogramMetric {
+  def integral[A](toValue: A => Long, toTags: A => List[String]): HistogramMetric[A] = new HistogramMetric[A] {
+    def tags(value: A) = toTags(value)
+    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+      client.histogram(aspect, toValue(v), t ++ tags(v): _*)
+  }
+  
+  def fractional[A](toValue: A => Double, toTags: A => List[String]): HistogramMetric[A] = new HistogramMetric[A] {
+    def tags(value: A) = toTags(value)
+    def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
+      client.histogram(aspect, toValue(v), t ++ tags(v): _*)
+  }
+  
+  implicit val intIsHistogramMetric    = integral[Int](_.toLong, _ => Nil)
+  implicit val longIsHistogramMetric   = integral[Long](identity, _ => Nil)
+  implicit val byteIsHistogramMetric   = integral[Byte](_.toLong, _ => Nil)
+  implicit val floatIsHistogramMetric  = fractional[Float](_.toDouble, _ => Nil)
+  implicit val doubleIsHistogramMetric = fractional[Double](identity, _ => Nil)
+}
+  

--- a/pico-statsd/src/main/scala/org/pico/statsd/HistogramMetric.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/HistogramMetric.scala
@@ -2,18 +2,32 @@ package org.pico.statsd
 
 import com.timgroup.statsd.StatsDClient
 
+/**
+  * Classifies value as a histogram metric.
+  * The trait is sealed so only smart constructors can be used to create instances.
+  */
 sealed trait HistogramMetric[A] {
   def tags(value: A): List[String]
   def send(client: StatsDClient, aspect: String, value: A, extraTags: List[String]): Unit
 }
 
 object HistogramMetric {
+  /**
+    * Construct a [[HistogramMetric]] instance that accepts integral values for a given type.
+    * @param toValue maps the value to an integral value
+    * @param toTags maps the value to value specific tags
+    */
   def integral[A](toValue: A => Long, toTags: A => List[String]): HistogramMetric[A] = new HistogramMetric[A] {
     def tags(value: A) = toTags(value)
     def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =
       client.histogram(aspect, toValue(v), t ++ tags(v): _*)
   }
   
+  /**
+    * Construct a [[HistogramMetric]] instance that accepts integral values for a given type.
+    * @param toValue maps the value to an integral value
+    * @param toTags maps the value to value specific tags
+    */
   def fractional[A](toValue: A => Double, toTags: A => List[String]): HistogramMetric[A] = new HistogramMetric[A] {
     def tags(value: A) = toTags(value)
     def send(client: StatsDClient, aspect: String, v: A, t: List[String]): Unit =

--- a/pico-statsd/src/main/scala/org/pico/statsd/package.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/package.scala
@@ -1,8 +1,31 @@
 package org.pico
 
+import com.timgroup.statsd.StatsDClient
+import org.pico.event.Sink
+
 package object statsd {
   val Ok = Status(0)
   val Warning = Status(1)
   val Critical = Status(2)
   val Unknown = Status(3)
+  
+  def statsSink[A](f: (StatsDClient, A) => Unit)
+               (implicit c: StatsDClient): Sink[A] = {
+    Sink[A](a => f(c, a))
+  }
+  
+  def counterSink[A](aspect: String, value: A, tags: String*)
+                    (implicit c: StatsDClient, m: CounterMetric[A]): Sink[A] = {
+    Sink[A](a => m.send(c, aspect, a, tags.toList))
+  }
+  
+  def gaugeSink[A](aspect: String, value: A, tags: String*)
+                  (implicit c: StatsDClient, m: GaugeMetric[A]): Sink[A] = {
+    Sink[A](a => m.send(c, aspect, a, tags.toList))
+  }
+  
+  def histogramSink[A](aspect: String, value: A, tags: String*)
+                      (implicit c: StatsDClient, m: HistogramMetric[A]): Sink[A] = {
+    Sink[A](a => m.send(c, aspect, a, tags.toList))
+  }
 }

--- a/pico-statsd/src/main/scala/org/pico/statsd/package.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/package.scala
@@ -9,6 +9,11 @@ package object statsd {
   val Critical = Status(2)
   val Unknown = Status(3)
   
+  /**
+    * Generic StatsD sink. Have a reference to both [[StatsDClient]] and a message
+    * and do what you want
+    * @param f handle the message using a StatsDClient provided
+    */
   def statsSink[A](f: (StatsDClient, A) => Unit)
                (implicit c: StatsDClient): Sink[A] = {
     Sink[A](a => f(c, a))

--- a/pico-statsd/src/main/scala/org/pico/statsd/package.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/package.scala
@@ -1,6 +1,5 @@
 package org.pico
 
-import com.timgroup.statsd.StatsDClient
 import org.pico.event.Sink
 
 package object statsd {
@@ -10,27 +9,27 @@ package object statsd {
   val Unknown = Status(3)
   
   /**
-    * Generic StatsD sink. Have a reference to both [[StatsDClient]] and a message
+    * Generic StatsD sink. Have a reference to both [[StatsdClient]] and a message
     * and do what you want
-    * @param f handle the message using a StatsDClient provided
+    * @param f handle the message using a StatsdClient provided
     */
-  def statsSink[A](f: (StatsDClient, A) => Unit)
-               (implicit c: StatsDClient): Sink[A] = {
+  def statsSink[A](f: (StatsdClient, A) => Unit)
+               (implicit c: StatsdClient): Sink[A] = {
     Sink[A](a => f(c, a))
   }
   
   def counterSink[A](aspect: String, value: A, tags: String*)
-                    (implicit c: StatsDClient, m: CounterMetric[A]): Sink[A] = {
+                    (implicit c: StatsdClient, m: CounterMetric[A]): Sink[A] = {
     Sink[A](a => m.send(c, aspect, a, tags.toList))
   }
   
   def gaugeSink[A](aspect: String, value: A, tags: String*)
-                  (implicit c: StatsDClient, m: GaugeMetric[A]): Sink[A] = {
+                  (implicit c: StatsdClient, m: GaugeMetric[A]): Sink[A] = {
     Sink[A](a => m.send(c, aspect, a, tags.toList))
   }
   
   def histogramSink[A](aspect: String, value: A, tags: String*)
-                      (implicit c: StatsDClient, m: HistogramMetric[A]): Sink[A] = {
+                      (implicit c: StatsdClient, m: HistogramMetric[A]): Sink[A] = {
     Sink[A](a => m.send(c, aspect, a, tags.toList))
   }
 }

--- a/pico-statsd/src/main/scala/org/pico/statsd/syntax/event/package.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/syntax/event/package.scala
@@ -1,16 +1,15 @@
 package org.pico.statsd.syntax
 
-import com.timgroup.statsd.StatsDClient
 import org.pico.event.{Sink, Source}
-import org.pico.statsd.{CounterMetric, GaugeMetric, HistogramMetric}
+import org.pico.statsd.{CounterMetric, GaugeMetric, HistogramMetric, StatsdClient}
 
 package object event {
   
   implicit class SourceOps_Common_Rht98nT[A](val self: Source[A]) extends AnyVal {
   
     @inline
-    def stats(f: (StatsDClient, A) => Unit)
-             (implicit c: StatsDClient): Source[A] = {
+    def stats(f: (StatsdClient, A) => Unit)
+             (implicit c: StatsdClient): Source[A] = {
       self.effect(a => f(c, a))
     }
   }
@@ -19,19 +18,19 @@ package object event {
     
     @inline
     def counting(aspect: String, tags: String*)
-               (implicit c: StatsDClient): Source[A] = {
+               (implicit c: StatsdClient): Source[A] = {
       self.effect(a => c.count(aspect, 1, tags: _*))
     }
   
     @inline
     def counting(aspect: String, delta: Long, tags: String*)
-               (implicit c: StatsDClient): Source[A] = {
+               (implicit c: StatsdClient): Source[A] = {
       self.effect(a => c.count(aspect, delta, tags: _*))
     }
   
     @inline
     def viaCounter(aspect: String, tags: String*)
-               (implicit c: StatsDClient, m: CounterMetric[A]): Source[A] = {
+               (implicit c: StatsdClient, m: CounterMetric[A]): Source[A] = {
       self.effect(a => m.send(c, aspect, a, tags.toList))
     }
   }
@@ -40,7 +39,7 @@ package object event {
     
     @inline
     def viaGauge(aspect: String, value: A, tags: String*)
-                    (implicit c: StatsDClient, m: GaugeMetric[A]): Source[A] = {
+                    (implicit c: StatsdClient, m: GaugeMetric[A]): Source[A] = {
       self.effect { a => m.send(c, aspect, a, tags.toList) }
     }
   }
@@ -49,7 +48,7 @@ package object event {
 
     @inline
     def viaHistogram(aspect: String, value: A, tags: String*)
-                 (implicit c: StatsDClient, m: HistogramMetric[A]): Source[A] = {
+                 (implicit c: StatsdClient, m: HistogramMetric[A]): Source[A] = {
       self.effect { a => m.send(c, aspect, a, tags.toList) }
     }
   }

--- a/pico-statsd/src/main/scala/org/pico/statsd/syntax/event/package.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/syntax/event/package.scala
@@ -1,7 +1,7 @@
 package org.pico.statsd.syntax
 
 import com.timgroup.statsd.StatsDClient
-import org.pico.event.Source
+import org.pico.event.{Sink, Source}
 import org.pico.statsd.{CounterMetric, GaugeMetric, HistogramMetric}
 
 package object event {

--- a/pico-statsd/src/main/scala/org/pico/statsd/syntax/event/package.scala
+++ b/pico-statsd/src/main/scala/org/pico/statsd/syntax/event/package.scala
@@ -1,0 +1,56 @@
+package org.pico.statsd.syntax
+
+import com.timgroup.statsd.StatsDClient
+import org.pico.event.Source
+import org.pico.statsd.{CounterMetric, GaugeMetric, HistogramMetric}
+
+package object event {
+  
+  implicit class SourceOps_Common_Rht98nT[A](val self: Source[A]) extends AnyVal {
+  
+    @inline
+    def stats(f: (StatsDClient, A) => Unit)
+             (implicit c: StatsDClient): Source[A] = {
+      self.effect(a => f(c, a))
+    }
+  }
+  
+  implicit class SourceOps_Counter_Rht98nT[A](val self: Source[A]) extends AnyVal {
+    
+    @inline
+    def counting(aspect: String, tags: String*)
+               (implicit c: StatsDClient): Source[A] = {
+      self.effect(a => c.count(aspect, 1, tags: _*))
+    }
+  
+    @inline
+    def counting(aspect: String, delta: Long, tags: String*)
+               (implicit c: StatsDClient): Source[A] = {
+      self.effect(a => c.count(aspect, delta, tags: _*))
+    }
+  
+    @inline
+    def viaCounter(aspect: String, tags: String*)
+               (implicit c: StatsDClient, m: CounterMetric[A]): Source[A] = {
+      self.effect(a => m.send(c, aspect, a, tags.toList))
+    }
+  }
+  
+  implicit class SourceOps_Gauge_Rht98nT[A](val self: Source[A]) extends AnyVal {
+    
+    @inline
+    def viaGauge(aspect: String, value: A, tags: String*)
+                    (implicit c: StatsDClient, m: GaugeMetric[A]): Source[A] = {
+      self.effect { a => m.send(c, aspect, a, tags.toList) }
+    }
+  }
+  
+  implicit class SourceOps_Histogram_Rht98nT[A](val self: Source[A]) extends AnyVal {
+
+    @inline
+    def viaHistogram(aspect: String, value: A, tags: String*)
+                 (implicit c: StatsDClient, m: HistogramMetric[A]): Source[A] = {
+      self.effect { a => m.send(c, aspect, a, tags.toList) }
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,11 +2,13 @@ import sbt.Keys._
 import sbt._
 
 object Build extends sbt.Build {  
-  val pico_atomic     = "org.pico"              %%  "pico-atomic"       % "0.2.1"
-  val pico_disposal   = "org.pico"              %%  "pico-disposal"     % "1.0.8"
-  val pico_event      = "org.pico"              %%  "pico-event"        % "5.0.0"
+  val pico_atomic     = "org.pico"              %%  "pico-atomic"           % "0.2.1"
+  val pico_disposal   = "org.pico"              %%  "pico-disposal"         % "1.0.8"
+  val pico_event      = "org.pico"              %%  "pico-event"            % "5.0.0"
+  
+  val statsd_client   = "com.datadoghq"         %   "java-dogstatsd-client" % "2.2"
 
-  val specs2_core     = "org.specs2"            %%  "specs2-core"       % "3.8.6"
+  val specs2_core     = "org.specs2"            %%  "specs2-core"           % "3.8.6"
 
   implicit class ProjectOps(self: Project) {
     def standard(theDescription: String) = {
@@ -32,7 +34,7 @@ object Build extends sbt.Build {
 
   lazy val `pico-statsd` = Project(id = "pico-statsd", base = file("pico-statsd"))
       .standard("Tiny publish-subscriber library")
-      .libs(pico_atomic, pico_disposal, pico_event) // , cats_core)
+      .libs(pico_atomic, pico_disposal, pico_event, statsd_client) // , cats_core)
       .testLibs(specs2_core)
 
   lazy val all = Project(id = "pico-statsd-project", base = file("."))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,8 +5,6 @@ object Build extends sbt.Build {
   val pico_atomic     = "org.pico"              %%  "pico-atomic"           % "0.2.1"
   val pico_disposal   = "org.pico"              %%  "pico-disposal"         % "1.0.8"
   val pico_event      = "org.pico"              %%  "pico-event"            % "5.0.0"
-  
-  val statsd_client   = "com.datadoghq"         %   "java-dogstatsd-client" % "2.2"
 
   val specs2_core     = "org.specs2"            %%  "specs2-core"           % "3.8.6"
 
@@ -34,7 +32,7 @@ object Build extends sbt.Build {
 
   lazy val `pico-statsd` = Project(id = "pico-statsd", base = file("pico-statsd"))
       .standard("Tiny publish-subscriber library")
-      .libs(pico_atomic, pico_disposal, pico_event, statsd_client) // , cats_core)
+      .libs(pico_atomic, pico_disposal, pico_event) // , cats_core)
       .testLibs(specs2_core)
 
   lazy val all = Project(id = "pico-statsd-project", base = file("."))


### PR DESCRIPTION
### Changes

- Tried to nicely deal with `StatsDClient`'s overloaded methods for `Long` and `Double` by providing metric typeclasses
- Tried to make metrics extensible via typeclass instances
- Each metric has its own typeclass so the same type can be treated differently for different metrics (counter, gauge, histogram).
- Implemented some `via*` methods that are intended to be used  as `source.viaGauge("myGauge").subscribe(...)`
- Implemented some common sinks for counter, histogram and gauge